### PR TITLE
[FEAT] 일기 월별 분기 작업 (#8)

### DIFF
--- a/functions/api/routes/calendar/CalendarGet.js
+++ b/functions/api/routes/calendar/CalendarGet.js
@@ -5,22 +5,26 @@ const statusCode = require('../../../constants/statusCode');
 const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const { calendarDB } = require('../../../db');
-const { default: axios } = require('axios');
-const { response } = require('express');
-
-
+const dayjs = require('dayjs');
 
 module.exports = async (req, res) => {
   const { userId } = req.params;
-  //유저 아이디가 없는 경우임
-if (!userId) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+  const { date } = req.query;
+
+  //유저 아이디와 오늘 날짜 없는 경우임
+  if (!userId) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+  if (!date) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
 
   let client;
+
+  // 오늘 날짜를 기준으로 월 시작과 마지막 검색
+  const startDate = dayjs(date).startOf('month').format('YYYY-MM-DD');
+  const endDate = dayjs(date).endOf('month').format('YYYY-MM-DD');
 
   try {
     client = await db.connect(req);
 
-    const calendar = await calendarDB.getCalendar(client, userId);  //userId를 통해 캘린더 디비에서 가져옴
+    const calendar = await calendarDB.getCalendar(client, userId, startDate, endDate); //userId를 통해 캘린더 디비에서 가져옴
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_CALENDER_SUCCESS, calendar));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
@@ -31,4 +35,3 @@ if (!userId) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode
     client.release();
   }
 };
-

--- a/functions/api/routes/calendar/index.js
+++ b/functions/api/routes/calendar/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
 
-router.get('/:userId', require('./CalendarGet'));
+router.get('/:userId', require('./CalendarGET'));
 
 module.exports = router;

--- a/functions/db/calendar.js
+++ b/functions/db/calendar.js
@@ -5,16 +5,18 @@ const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
  * @캘린더 불러오기
  */
 
+const getCalendar = async (client, userId, startDate, endDate) => {
+  const { rows } = await client.query(
+    `
+      SELECT *
+      FROM diary
+      WHERE user_id = $1 
+      AND created_at BETWEEN $2 AND $3
+      ORDER BY created_at
+    `,
+    [userId, startDate, endDate],
+  );
+  return convertSnakeToCamel.keysToCamel(rows); //전체 리스트를 가져오고싶어서 rows
+};
 
-  const getCalendar = async (client, userId) => {
-    const { rows } = await client.query(
-      `
-      SELECT * FROM "diary" 
-      WHERE user_id = $1
-      `,
-      [userId], 
-    );
-    return convertSnakeToCamel.keysToCamel(rows);  //전체 리스트를 가져오고싶어서 rows
-  };
-
-  module.exports = { getCalendar};
+module.exports = { getCalendar };


### PR DESCRIPTION
## 작업한 브랜치
feature/#8-set-calendar

## 작업사항

query로 오늘 날짜를 넣어주면 해당 달의 일기를 모두 내려주는 형식입니다.

### 일기 월별 조회 API

- 해당 월의 일기 없음
<img width="800" alt="Screen Shot 2022-05-19 at 11 38 03 AM" src="https://user-images.githubusercontent.com/75535902/169195169-55475870-3d31-4720-b15f-2816d08aa2c9.png">

- 4월 일기
<img width="800" alt="Screen Shot 2022-05-19 at 11 37 51 AM" src="https://user-images.githubusercontent.com/75535902/169195143-df0236a2-a354-48b3-9ccc-3bc1b69699a2.png">

- 5월 일기
<img width="800" alt="Screen Shot 2022-05-19 at 11 37 44 AM" src="https://user-images.githubusercontent.com/75535902/169195129-74173839-5ef5-4478-83cc-ac7126e592af.png">

Resolved: #8 




