### PR TITLE
[FEAT] 일기 조회 API 수정 (#11)

### DIFF
--- a/functions/api/routes/calendar/CalendarContentGET.js
+++ b/functions/api/routes/calendar/CalendarContentGET.js
@@ -1,0 +1,38 @@
+const _ = require('lodash');
+const functions = require('firebase-functions');
+const util = require('../../../lib/util');
+const statusCode = require('../../../constants/statusCode');
+const responseMessage = require('../../../constants/responseMessage');
+const db = require('../../../db/db');
+const { calendarDB } = require('../../../db');
+const axios = require('axios');
+const dayjs = require('dayjs');
+
+/**
+ *  @route GET /:userId/diary
+ *  @desc 캘린더 전체 조회
+ *  @access Private
+ */
+
+module.exports = async (req, res) => {
+  const { userId } = req.params;
+
+  //유저 아이디와 오늘 날짜 없는 경우임
+  if (!userId) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+
+  let client;
+
+  try {
+    client = await db.connect(req);
+
+    const calendar = await calendarDB.findDiaryByUserId(client, userId); //userId, startDate, endDate를 통해 기간 내에 속한 캘린더 디비에서 가져옴
+    res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_CALENDER_SUCCESS, calendar));
+  } catch (error) {
+    functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
+    console.log(error);
+
+    res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+  } finally {
+    client.release();
+  }
+};

--- a/functions/api/routes/calendar/CalendarContentGET.js
+++ b/functions/api/routes/calendar/CalendarContentGET.js
@@ -5,8 +5,6 @@ const statusCode = require('../../../constants/statusCode');
 const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const { calendarDB } = require('../../../db');
-const axios = require('axios');
-const dayjs = require('dayjs');
 
 /**
  *  @route GET /:userId/diary

--- a/functions/api/routes/calendar/CalendarGet.js
+++ b/functions/api/routes/calendar/CalendarGet.js
@@ -25,6 +25,12 @@ module.exports = async (req, res) => {
     client = await db.connect(req);
 
     const calendar = await calendarDB.getCalendar(client, userId, startDate, endDate); //userId, startDate, endDate를 통해 기간 내에 속한 캘린더 디비에서 가져옴
+    calendar.map((obj) => {
+      /**
+       * createdAt format 수정
+       */
+      obj.createdAt = dayjs(`${obj.createdAt}`).format('YYYY-MM-DD ddd HH:mm');
+    });
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_CALENDER_SUCCESS, calendar));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);

--- a/functions/api/routes/calendar/CalendarGet.js
+++ b/functions/api/routes/calendar/CalendarGet.js
@@ -24,7 +24,7 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
-    const calendar = await calendarDB.getCalendar(client, userId, startDate, endDate); //userId를 통해 캘린더 디비에서 가져옴
+    const calendar = await calendarDB.getCalendar(client, userId, startDate, endDate); //userId, startDate, endDate를 통해 기간 내에 속한 캘린더 디비에서 가져옴
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_CALENDER_SUCCESS, calendar));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);

--- a/functions/api/routes/calendar/index.js
+++ b/functions/api/routes/calendar/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
-router.get('/:userId', require('./CalendarGET'));
+router.get('/:userId', require('./CalendarGET')); // 일정 기한 내 Calendar 가져오기
+router.get('/:userId/diary', require('./CalendarContentGET')); // 유저가 작성한 모든 Calendar 가져오기
 
 module.exports = router;

--- a/functions/db/calendar.js
+++ b/functions/db/calendar.js
@@ -7,16 +7,47 @@ const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
 
 const getCalendar = async (client, userId, startDate, endDate) => {
   const { rows } = await client.query(
-    `
-      SELECT *
-      FROM diary
-      WHERE user_id = $1 
-      AND created_at BETWEEN $2 AND $3
-      ORDER BY created_at
-    `,
+    `SELECT DISTINCT d.id, 
+    d.content,
+    d.emotion_id,
+    m.title,
+    m.singer,
+    m.cover,
+    m.url,
+    d.created_at
+    FROM diary AS d
+    LEFT OUTER JOIN music as m ON d.music_id = m.id 
+    WHERE d.user_id = $1
+    AND d.created_at BETWEEN $2 AND $3
+    ORDER BY d.created_at
+  `,
     [userId, startDate, endDate],
   );
   return convertSnakeToCamel.keysToCamel(rows); //전체 리스트를 가져오고싶어서 rows
 };
 
-module.exports = { getCalendar };
+/**
+ * @전체 일기 모두 가져오기
+ */
+
+const findDiaryByUserId = async (client, userId) => {
+  const { rows } = await client.query(
+    `SELECT DISTINCT d.id, 
+    d.content,
+    d.emotion_id,
+    m.title,
+    m.singer,
+    m.cover,
+    m.url,
+    d.created_at
+    FROM diary AS d
+    LEFT OUTER JOIN music as m ON d.music_id = m.id 
+    WHERE d.user_id = $1
+    ORDER BY d.created_at
+  `,
+    [userId],
+  );
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
+module.exports = { getCalendar, findDiaryByUserId };


### PR DESCRIPTION
일기 조회 시 저장된 음악 정보도 가져오는 방식으로 수정했습니다!
그리고 기한 별로가 아닌 전체 일기를 가져오는 코드도 추가했습니다
모아보기 뷰에 들어갈 조회 API의 경우에는 요일도 함께 가져옵니다!


- Resolved: #11